### PR TITLE
Update of README to point to eotarchive.org for more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # End of Term Web Archive
 
-This is the public repository for the End of Term Web Archive project. The End of Term Web Archive is a collaborative initiative that collects, preserves, and makes accessible United States Government websites at the end of presidential administrations. Beginning in 2008, the End of Term Web Archive has thus far preserved websites from administration changes in 2008, 2012, 2016, 2020, and is currently working to archive content from the 2024 electoral season. 
+This is the public repository to collect seed lists for the End of Term Web Archive project for the 2024 electoral season. The End of Term Web Archive is a collaborative initiative that collects, preserves, and makes accessible United States Government websites at the end of presidential administrations. Beginning in 2008, the End of Term Web Archive has thus far preserved websites from administration changes in 2008, 2012, 2016, 2020, and 2024.
 
-For the End of Term 2024 web archive, the Library of Congress, the Internet Archive, University of North Texas Libraries, Stanford University Libraries, the U.S. Government Publishing Office, and the National Archives and Records Administration (NARA) have joined together to preserve public United States Government websites at the end of the current presidential administration ending January 20, 2025. Partners are joining together to select, collect, preserve, and make the web archives available for public access and research use. This archive is intended to document and preserve the federal government's presence on the web during the presidential transition and to expand and enhance the existing collections of the partner institutions.
+For the End of Term 2024 web archive, [partners](https://eotarchive.org/partners/) have joined together to preserve public United States Government websites of the presidential administration ending January 20, 2025, collaborating to select, collect, preserve, and make the web archives available for public access and research use. This archive is intended to document and preserve the federal government's presence on the web during the presidential transition and to expand and enhance the existing collections of the partner institutions.
 
 ## Collecting Scope
 The End of Term Web Archive contains federal government websites (.gov, .mil, government websites not on the .gov domain, government social media accounts, public-nominated government sites, etc.) in the Legislative, Executive, or Judicial branches of the government. Local or state government websites or any other sites not part of the federal government domain are considered out of scope; however, some websites exist in a liminal space that makes "official" federal status hard to determine. The website seed lists published in this repository represent the full extent of the sites selected for archiving.
@@ -14,17 +14,14 @@ The project has two phases: A broad, comprehensive baseline crawl of identified 
 
 **Comprehensive Crawl** - The Internet Archive will undertake a comprehensive crawl of the URLs identified for this project beginning in October 2024 and again in early 2025 after the inauguration.
 
-**Prioritized Crawl** - The project team is calling upon government information specialists, including librarians, political and social science researchers, and academics to assist in the selection and prioritization of the selected web sites to be included in the collection, as well as identifying the frequency and depth of collecting. The schedule for crawling of the prioritized URLs will be distributed across the project team and announced as the project gets underway.
+**Prioritized Crawl** - The project team is calling upon government information specialists, including librarians, political and social science researchers, and academics to assist in the selection and prioritization of the selected web sites to be included in the collection, as well as identifying the frequency and depth of collecting.
 
 ## Access
-* The [End of Term Web Archive](https://eotarchive.org) portal provides access to archived sites collected as part of the project.
+* [eotarchive.org](https://eotarchive.org) provides information on how to access archived sites collected as part of the project.
 * The online nomination tool for 2024 can be found at [End of Term 2024 Nomination Tool](https://digital2.library.unt.edu/nomination/eth2024/about/).
 
 ## Presentations & Papers
-* 2016-12-02: "[After the Harvest: Preservation, Access, and Researcher Services for the 2016 End of Term Archive](https://docs.google.com/presentation/d/1_eBnTjaTeFnD5diGhIWDy00Vgousffl5kCF-ErZ0wZ0/edit#slide=id.g153e4cbb38_0_0)" at [CNI Fall 2016 Meeting](https://www.cni.org/events/membership-meetings/past-meetings/fall-2016).
-* 2016-07-17: "[Harvesting Democracy: Archiving Federal Government Web Content at End of Term](https://docs.google.com/presentation/d/17-VoM_8ykrWdX-ys-L66xedPwTcQBVsdcW-kQdfVoDc/edit#slide=id.g153e4cbb38_0_0)" at [American Association of Law Libraries 2016 Conference](https://web.archive.org/web/20160920095335/http://www.aallnet.org/mm/Education/aall2go/amrecordings/aall2016/aall16a7.html).
-* 2016-06-22: "[Exploratory Analysis of the End of Term Web Archive: Comparing Two Collections](http://digital.library.unt.edu/ark:/67531/metadc854115/m2/1/high_res_d/wadl_2016_eot.pdf)" at [Web Archiving and Digital Libraries 2016](https://web.archive.org/web/20160920093038/http://fox.cs.vt.edu/wadl2016.html).
-* 2013-02-01: "[Classification of the End of Term Archive: Extending Collection Development Practices to Web Archives](http://digital.library.unt.edu/ark:/67531/metadc152437/m2/1/high_res_d/LG-06-09-0174-09_UNT_Feb2013_FINAL.pdf)" [IMLS Final Project Report for Award LG-06-09-0174-09] (https://www.imls.gov/grants/awarded/lg-06-09-0174-09).
+Please visit [eotarchive.org](https://eotarchive.org/presentations/) for a list of papers and presentations tied to the End of Term project and for mentions of the project in the press.
 
 ## How to connect
 * Contact the [End of Term team](mailto:eot-info@archive.org).


### PR DESCRIPTION
This updates out-of-date info copied from past READMEs by pointing users to the up-to-date info on eotarchive.org.

Want to take a look at this @vphill ?